### PR TITLE
Add the Azure Boards badge to the README

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -1,3 +1,4 @@
+[![Board Status](https://dev.azure.com/executech/d9801214-ce08-4062-b742-24ee756e36f2/664aae17-a5c0-477e-b4ef-8d011773dadf/_apis/work/boardbadge/fb0b109c-ada9-4bc4-9304-2b8da2212236)](https://dev.azure.com/executech/d9801214-ce08-4062-b742-24ee756e36f2/_boards/board/t/664aae17-a5c0-477e-b4ef-8d011773dadf/Microsoft.RequirementCategory)
 # Azure
 
 - Create a new function app inside the Azure Portal.


### PR DESCRIPTION
Add the Azure Boards badge for the board used to track the work for this repository. Fixes [AB#1](https://dev.azure.com/executech/d9801214-ce08-4062-b742-24ee756e36f2/_workitems/edit/1). See the [status badge configuration](https://aka.ms/azureboardsgithub-badge) documentation for more information.